### PR TITLE
www.gifless.com - not working

### DIFF
--- a/store.json
+++ b/store.json
@@ -978,7 +978,7 @@
       {
         "title": "Gifless",
         "desc": "Create emoji and text gifs in seconds",
-        "url": "https://www.gifless.com/"
+        "url": "https://gifless.herokuapp.com/"
       },
       {
         "title": "Learn Git",


### PR DESCRIPTION
I changed the link for "www.gifless.com" to "https://gifless.herokuapp.com/" because seems to not work anymore :)