### PR TITLE
Turn off "Format on Save" in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}


### PR DESCRIPTION
If a contributor has this (globally) turned on, it would wrongly format code everytime a file is saved.