### PR TITLE
fixed broken link

### DIFF
--- a/resources/css.json
+++ b/resources/css.json
@@ -35,7 +35,7 @@
     {
       "title": "30 Seconds of Code",
       "desc": "A curated collection of useful CSS snippets you can understand in 30 seconds or less.",
-      "url": "https://30-seconds.github.io/30-seconds-of-css/",
+      "url": "https://www.30secondsofcode.org/css/",
       "tags": ["tips", "tricks", "collection"]
     },
     {


### PR DESCRIPTION
fixes https://github.com/webgems/webgems/issues/219

Replacing an outdated link "https://30-seconds.github.io/30-seconds-of-css/" with "https://www.30secondsofcode.org/css/"